### PR TITLE
Switch to use `actions` to include the role once

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Node exporter only:
 ```yaml
 - hosts: servers
   roles:
-    - { role: prometheus, action: "node_exporter" }
+    - { role: prometheus, actions: ["node_exporter"] }
 ```
 
 Redis exporter only:
@@ -70,7 +70,7 @@ Redis exporter only:
 ```yaml
 - hosts: servers
   roles:
-    - { role: prometheus, action: "redis_exporter" }
+    - { role: prometheus, actions: ["redis_exporter"] }
 ```
 
 Postgres exporter only:
@@ -78,7 +78,7 @@ Postgres exporter only:
 ```yaml
 - hosts: servers
   roles:
-    - { role: prometheus, action: "postgres_exporter" }
+    - { role: prometheus, actions: ["postgres_exporter"] }
 ```
 
 ## License

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,8 +1,8 @@
 - import_tasks: node_exporter.yml
-  when: action == "node_exporter"
+  when: '"node_exporter" in actions'
 
 - import_tasks: redis_exporter.yml
-  when: action == "redis_exporter"
+  when: '"redis_exporter" in actions'
 
 - import_tasks: postgres_exporter.yml
-  when: action == "postgres_exporter"
+  when: '"postgres_exporter" in actions'


### PR DESCRIPTION
Run all the exporters required with one role line. This will skip all of
the extra skips we see when including the role more than once