### PR TITLE
Switch from become_user to owner/group for templating

### DIFF
--- a/tasks/postgres_exporter.yml
+++ b/tasks/postgres_exporter.yml
@@ -53,8 +53,9 @@
     src: postgres_exporter.env.j2
     dest: /home/prometheus/postgres_exporter/env
     mode: 0644
+    owner: prometheus
+    group: prometheus
   become: yes
-  become_user: prometheus
   notify:
     - restart postgres_exporter
 

--- a/tasks/redis_exporter.yml
+++ b/tasks/redis_exporter.yml
@@ -35,8 +35,9 @@
     src: redis_exporter.env.j2
     dest: /home/prometheus/redis_exporter/env
     mode: 0644
+    owner: prometheus
+    group: prometheus
   become: yes
-  become_user: prometheus
   notify:
     - restart redis_exporter
 


### PR DESCRIPTION
When templating as the prometheus user

There are some failures when using this in a newer ansible version. This should fix them.